### PR TITLE
Enhance login UX with accessibility tweaks

### DIFF
--- a/frontend/src/app/auth/pages/login-page/login-page.component.css
+++ b/frontend/src/app/auth/pages/login-page/login-page.component.css
@@ -1,1 +1,21 @@
 
+:host {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.login-card {
+  max-width: 26rem;
+  width: 100%;
+}
+
+.password-toggle {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  padding: 0;
+}

--- a/frontend/src/app/auth/pages/login-page/login-page.component.html
+++ b/frontend/src/app/auth/pages/login-page/login-page.component.html
@@ -1,29 +1,45 @@
-<h3>
-  Inicia sesión con tu cuenta
-</h3>
+<div class="card login-card shadow-sm border-0">
+  <div class="card-body">
+    <h3 class="card-title text-center mb-4">
+      Inicia sesión con tu cuenta
+    </h3>
 
-<form [formGroup]="formSignIn" (ngSubmit)="signIn()" class="">
-  <input type="email" placeholder="Correo" class="form-control mb-3" formControlName="correo">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
-    Ingresa tu correo electronico
-  </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2"
-    *ngIf="(correo.touched && correo.value && correo.errors?.email)">
-    Correo electronico no valido
-  </div>
+    <form [formGroup]="formSignIn" (ngSubmit)="signIn()">
+      <div class="form-floating mb-3">
+        <input type="email" id="correoInput" class="form-control"
+          formControlName="correo" placeholder="Correo electrónico" autocomplete="email" autofocus
+          [ngClass]="{'is-invalid': correo.touched && correo.invalid}">
+        <label for="correoInput">Correo electrónico</label>
+        <div class="invalid-feedback" *ngIf="correo.touched && correo.errors?.required">
+          Ingresa tu correo electronico
+        </div>
+        <div class="invalid-feedback" *ngIf="correo.touched && correo.value && correo.errors?.email">
+          Correo electronico no valido
+        </div>
+      </div>
 
-  <input type="password" placeholder="Contraseña" class="form-control mb-3" formControlName="contrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.dirty && contrasenia.touched && contrasenia.errors?.required)">
-    Ingresa tu contraseña
-  </div>
+      <div class="form-floating mb-3 position-relative">
+        <input [type]="showPassword ? 'text' : 'password'" id="contraseniaInput"
+          class="form-control" formControlName="contrasenia" placeholder="Contraseña" autocomplete="current-password"
+          [ngClass]="{'is-invalid': contrasenia.touched && contrasenia.invalid}">
+        <label for="contraseniaInput">Contraseña</label>
+        <button type="button" class="password-toggle position-absolute top-50 end-0 translate-middle-y me-3"
+          (click)="togglePassword()" [attr.aria-label]="showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'">
+          <span class="material-symbols-outlined">{{ showPassword ? 'visibility_off' : 'visibility' }}</span>
+        </button>
+        <div class="invalid-feedback" *ngIf="contrasenia.touched && contrasenia.errors?.required">
+          Ingresa tu contraseña
+        </div>
+      </div>
 
-  <div class="d-flex justify-content-end mb-3">
-    <a [routerLink]="['../forgot-password']">¿Olvidaste tu contraseña?</a>
+      <div class="d-flex justify-content-end mb-3">
+        <a [routerLink]="['../forgot-password']">¿Olvidaste tu contraseña?</a>
+      </div>
+      <button type="submit" class="btn btn-primary w-100 mb-3" [disabled]="formSignIn.invalid">Ingresar</button>
+    </form>
+
+    <p class="text-center m-0">
+      ¿No tienes una cuenta? <a [routerLink]="['../sign-up']">Crear una cuenta</a>
+    </p>
   </div>
-  <button type="submit" class="btn btn-primary w-100 mb-3" [disabled]="!formSignIn.valid">Ingresar</button>
-</form>
-<p class="center">
-  ¿No tienes una cuenta? <a [routerLink]="['../sign-up']">Crear una cuenta</a>
-</p>
+</div>

--- a/frontend/src/app/auth/pages/login-page/login-page.component.ts
+++ b/frontend/src/app/auth/pages/login-page/login-page.component.ts
@@ -14,6 +14,7 @@ import { Md5 } from 'md5-typescript';
 export class LoginPageComponent implements OnInit {
 
   formSignIn: any
+  showPassword = false
 
   constructor(
     private authService: AuthService,
@@ -38,6 +39,10 @@ export class LoginPageComponent implements OnInit {
 
   get contrasenia() {
     return this.formSignIn.get('contrasenia')
+  }
+
+  togglePassword() {
+    this.showPassword = !this.showPassword
   }
 
   signIn() {


### PR DESCRIPTION
## Summary
- center login form vertically and allow full width
- add email/password autocomplete and autofocus
- refine layout and password toggle button

## Testing
- `npx -p @angular/cli@20.0.2 ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_684b9f4d221483318e241c8f7658f28e