### PR TITLE
Improve auth module UI

### DIFF
--- a/frontend/src/app/auth/pages/confirmar-cuenta/confirmar-cuenta.component.ts
+++ b/frontend/src/app/auth/pages/confirmar-cuenta/confirmar-cuenta.component.ts
@@ -7,12 +7,10 @@ import { ToastrService } from 'ngx-toastr';
 @Component({
   selector: 'app-confirmar-cuenta',
   template: `
-    <h3>
-      Confirmacion de cuenta.
-    </h3>
-    <p class="opacity-75">
-      !Bienvenido¡
-    </p>
+    <div class="text-center p-4">
+      <h3 class="mb-2 fw-semibold">Confirmación de cuenta</h3>
+      <p class="opacity-75">¡Bienvenido!</p>
+    </div>
   `,
   styleUrls: ['./confirmar-cuenta.component.css']
 })

--- a/frontend/src/app/auth/pages/forgot-pwd-page/forgot-pwd-page.component.html
+++ b/frontend/src/app/auth/pages/forgot-pwd-page/forgot-pwd-page.component.html
@@ -1,20 +1,19 @@
-<h3 class="mb-3">
+<h3 class="mb-4 fw-semibold">
   Recuperar contraseña
 </h3>
-
-<form [formGroup]="formForgotPwd" (ngSubmit)="forgotPwd()">
-  <input type="email" placeholder="Correo" class="form-control mb-3" formControlName="correo">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
+<form [formGroup]="formForgotPwd" (ngSubmit)="forgotPwd()" class="auth-form">
+  <div class="form-floating mb-2">
+    <input type="email" id="correo" placeholder="Correo" class="form-control" formControlName="correo">
+    <label for="correo">Correo</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
     Ingresa tu correo electronico
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.value && correo.errors?.email)">
+  <div class="text-danger small text-center mb-3" *ngIf="(correo.touched && correo.value && correo.errors?.email)">
     Correo electronico no valido
   </div>
-
   <button type="submit" class="btn btn-primary w-100 mb-3" [disabled]="!formForgotPwd.valid">Ingresar</button>
 </form>
-<p class="center">
+<p class="text-center small">
   ¿Ya tienes una cuenta? <a [routerLink]="['../sign-in']">Iniciar sesión</a>
 </p>

--- a/frontend/src/app/auth/pages/layout-auth-page/layout-auth-page.component.css
+++ b/frontend/src/app/auth/pages/layout-auth-page/layout-auth-page.component.css
@@ -1,3 +1,19 @@
+
+:host {
+  display: block;
+}
+
+.auth-wrapper {
+  max-width: 900px;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.auth-carousel {
+  background-color: var(--point-primary-color);
+  color: #fff;
+}
+
 @media (max-width: 576px) {
   .d-xs-none {
     display: none;

--- a/frontend/src/app/auth/pages/layout-auth-page/layout-auth-page.component.html
+++ b/frontend/src/app/auth/pages/layout-auth-page/layout-auth-page.component.html
@@ -1,17 +1,12 @@
-<div class="h-75 w-75 row d-flex justify-content-center align-items-center shadow-lg">
-  <div class="col-12 col-md-9 col-lg-6">
-    <div class="container">
-      <h1>
-        Point
-      </h1>
-      <p class="opacity-75">
-        Bienvenido de vuelta
-      </p>
+<div class="container-fluid min-vh-100 d-flex align-items-center justify-content-center auth-layout">
+  <div class="row shadow-lg auth-wrapper w-100">
+    <div class="col-12 col-lg-6 p-4 bg-white">
+      <h1 class="mb-0 text-primary fw-bold">Point</h1>
+      <p class="text-muted mb-4">Bienvenido de vuelta</p>
       <router-outlet></router-outlet>
     </div>
-  </div>
-
-  <div class="d-none d-lg-block col-md-6 bg-primary h-100">
-    <app-carousel class="w-100"></app-carousel>
+    <div class="d-none d-lg-block col-lg-6 p-0 auth-carousel">
+      <app-carousel class="w-100 h-100"></app-carousel>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/auth/pages/login-page/login-page.component.html
+++ b/frontend/src/app/auth/pages/login-page/login-page.component.html
@@ -1,29 +1,29 @@
-<h3>
+<h3 class="mb-4 fw-semibold">
   Inicia sesión con tu cuenta
 </h3>
-
-<form [formGroup]="formSignIn" (ngSubmit)="signIn()" class="">
-  <input type="email" placeholder="Correo" class="form-control mb-3" formControlName="correo">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
+<form [formGroup]="formSignIn" (ngSubmit)="signIn()" class="auth-form">
+  <div class="form-floating mb-2">
+    <input type="email" id="correo" placeholder="Correo" class="form-control" formControlName="correo">
+    <label for="correo">Correo</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
     Ingresa tu correo electronico
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2"
-    *ngIf="(correo.touched && correo.value && correo.errors?.email)">
+  <div class="text-danger small text-center mb-3" *ngIf="(correo.touched && correo.value && correo.errors?.email)">
     Correo electronico no valido
   </div>
-
-  <input type="password" placeholder="Contraseña" class="form-control mb-3" formControlName="contrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.dirty && contrasenia.touched && contrasenia.errors?.required)">
+  <div class="form-floating mb-2">
+    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control" formControlName="contrasenia">
+    <label for="contrasenia">Contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-3" *ngIf="(contrasenia.dirty && contrasenia.touched && contrasenia.errors?.required)">
     Ingresa tu contraseña
   </div>
-
   <div class="d-flex justify-content-end mb-3">
     <a [routerLink]="['../forgot-password']">¿Olvidaste tu contraseña?</a>
   </div>
   <button type="submit" class="btn btn-primary w-100 mb-3" [disabled]="!formSignIn.valid">Ingresar</button>
 </form>
-<p class="center">
+<p class="text-center small">
   ¿No tienes una cuenta? <a [routerLink]="['../sign-up']">Crear una cuenta</a>
 </p>

--- a/frontend/src/app/auth/pages/new-member/new-member.component.html
+++ b/frontend/src/app/auth/pages/new-member/new-member.component.html
@@ -1,39 +1,40 @@
-<h3>
+<h3 class="mb-4 fw-semibold">
   Unete a tu equipo
 </h3>
-
-<form [formGroup]="formMember" (ngSubmit)="createUser()">
-  <input type="text" placeholder="Nombre" class="form-control mb-3" formControlName="nombre">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(nombre.touched && nombre.dirty && nombre.errors?.required)">
+<form [formGroup]="formMember" (ngSubmit)="createUser()" class="auth-form">
+  <div class="form-floating mb-2">
+    <input type="text" id="nombre" placeholder="Nombre" class="form-control" formControlName="nombre">
+    <label for="nombre">Nombre</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(nombre.touched && nombre.dirty && nombre.errors?.required)">
     Ingresa tu nombre
   </div>
-
-  <input type="email" placeholder="Correo electronico" class="form-control mb-3" formControlName="correo">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
+  <div class="form-floating mb-2">
+    <input type="email" id="correo" placeholder="Correo electronico" class="form-control" formControlName="correo">
+    <label for="correo">Correo electronico</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
     Ingresa tu correo
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.value && correo.errors?.email)">
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.value && correo.errors?.email)">
     Correo no valido
   </div>
-
-  <input type="password" placeholder="Contraseña" class="form-control mb-3" formControlName="contrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
+  <div class="form-floating mb-2">
+    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control" formControlName="contrasenia">
+    <label for="contrasenia">Contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
     Ingresa tu contraseña
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.errors?.minlength || contrasenia.errors?.maxlength)">
+  <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.errors?.minlength || contrasenia.errors?.maxlength)">
     La contraseña debe tener de 8 a 12 caracteres
   </div>
-
-  <input type="password" placeholder="Confirmar contraseña" class="form-control mb-3" formControlName="confContrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(formMember.errors?.PasswordNoMatch && confContrasenia.value)">
+  <div class="form-floating mb-2">
+    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control" formControlName="confContrasenia">
+    <label for="confContrasenia">Confirmar contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-3" *ngIf="(formMember.errors?.PasswordNoMatch && confContrasenia.value)">
     La contraseña no coincide
   </div>
-
   <button type="submit" class="btn btn-primary w-100" [disabled]="!formMember.valid">Registrarse</button>
 </form>

--- a/frontend/src/app/auth/pages/restore-pwd-page/restore-pwd-page.component.html
+++ b/frontend/src/app/auth/pages/restore-pwd-page/restore-pwd-page.component.html
@@ -1,33 +1,33 @@
-<h3 class="mb-3">
+<h3 class="mb-4 fw-semibold">
   Ingresa una nueva contraseña
 </h3>
-
-<form [formGroup]="formRestorePwd" (ngSubmit)="restorePwd()">
-  <input type="email" placeholder="Correo" class="form-control mb-3" formControlName="correo">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
+<form [formGroup]="formRestorePwd" (ngSubmit)="restorePwd()" class="auth-form">
+  <div class="form-floating mb-2">
+    <input type="email" id="correo" placeholder="Correo" class="form-control" formControlName="correo">
+    <label for="correo">Correo</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
     Ingresa tu correo electronico
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.value && correo.errors?.email)">
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.value && correo.errors?.email)">
     Correo electronico no valido
   </div>
-
-  <input type="password" placeholder="Nueva contraseña" class="form-control mb-3" formControlName="contrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
+  <div class="form-floating mb-2">
+    <input type="password" id="contrasenia" placeholder="Nueva contraseña" class="form-control" formControlName="contrasenia">
+    <label for="contrasenia">Nueva contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
     Ingresa tu contraseña
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.errors?.minlength || contrasenia.errors?.maxlength)">
+  <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.errors?.minlength || contrasenia.errors?.maxlength)">
     La contraseña debe tener de 8 a 12 caracteres
   </div>
-
-  <input type="password" placeholder="Confirmar contraseña" class="form-control mb-3" formControlName="confContrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(formRestorePwd.errors?.PasswordNoMatch && confContrasenia.value)">
+  <div class="form-floating mb-2">
+    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control" formControlName="confContrasenia">
+    <label for="confContrasenia">Confirmar contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-3" *ngIf="(formRestorePwd.errors?.PasswordNoMatch && confContrasenia.value)">
     La contraseña no coincide
   </div>
-
   <button type="submit" class="btn btn-primary w-100" [disabled]="!formRestorePwd.valid">Ingresar</button>
 </form>

--- a/frontend/src/app/auth/pages/signup-page/signup-page.component.html
+++ b/frontend/src/app/auth/pages/signup-page/signup-page.component.html
@@ -1,46 +1,47 @@
-<h3>
+<h3 class="mb-4 fw-semibold">
   Crea una cuenta
 </h3>
-
-<form [formGroup]="formSignUp" (ngSubmit)="createUser()">
-
-  <input type="text" placeholder="Nombre" class="form-control mb-3" formControlName="nombre">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(nombre.touched && nombre.dirty && nombre.errors?.required)">
+<form [formGroup]="formSignUp" (ngSubmit)="createUser()" class="auth-form">
+  <div class="form-floating mb-2">
+    <input type="text" id="nombre" placeholder="Nombre" class="form-control" formControlName="nombre">
+    <label for="nombre">Nombre</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(nombre.touched && nombre.dirty && nombre.errors?.required)">
     Ingresa tu nombre
   </div>
-
-  <input type="email" placeholder="Correo electronico" class="form-control mb-3" formControlName="correo">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
+  <div class="form-floating mb-2">
+    <input type="email" id="correo" placeholder="Correo electronico" class="form-control" formControlName="correo">
+    <label for="correo">Correo electronico</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
     Ingresa tu correo
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(correo.touched && correo.value && correo.errors?.email)">
+  <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.value && correo.errors?.email)">
     Correo no valido
   </div>
-
-  <input type="text" placeholder="Nombre de tu equipo" class="form-control mb-3" formControlName="nombre_equipo">
-
-  <input type="password" placeholder="Contraseña" class="form-control mb-3" formControlName="contrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
+  <div class="form-floating mb-2">
+    <input type="text" id="nombre_equipo" placeholder="Nombre de tu equipo" class="form-control" formControlName="nombre_equipo">
+    <label for="nombre_equipo">Nombre de tu equipo</label>
+  </div>
+  <div class="form-floating mb-2">
+    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control" formControlName="contrasenia">
+    <label for="contrasenia">Contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
     Ingresa tu contraseña
   </div>
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(contrasenia.errors?.minlength || contrasenia.errors?.maxlength)">
+  <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.errors?.minlength || contrasenia.errors?.maxlength)">
     La contraseña debe tener de 8 a 12 caracteres
   </div>
-
-  <input type="password" placeholder="Confirmar contraseña" class="form-control mb-3" formControlName="confContrasenia">
-  <div class="d-flex justify-content-center alert alert-danger w-100 p-2 mb-3"
-    *ngIf="(formSignUp.errors?.PasswordNoMatch && confContrasenia.value)">
+  <div class="form-floating mb-2">
+    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control" formControlName="confContrasenia">
+    <label for="confContrasenia">Confirmar contraseña</label>
+  </div>
+  <div class="text-danger small text-center mb-3" *ngIf="(formSignUp.errors?.PasswordNoMatch && confContrasenia.value)">
     La contraseña no coincide
   </div>
-
   <button type="submit" class="btn btn-primary w-100 mb-3" [disabled]="!formSignUp.valid">Registrarse</button>
 </form>
-
-<p class="center">
+<p class="text-center small">
   ¿Ya tienes una cuenta? <a [routerLink]="['../sign-in']">Iniciar sesión</a>
 </p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -23,3 +23,25 @@
   --bs-primary-rgb: var(--point-rgb-primary-color);
   --bs-body-color: var(--point-primary-text);
 }
+
+/* Auth module styles */
+.auth-layout {
+  background-color: var(--point-bg-primary);
+}
+
+.auth-wrapper {
+  background-color: #fff;
+}
+
+.auth-form .form-control {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+}
+
+.auth-form .form-floating > label {
+  color: var(--point-secondary-text);
+}
+
+.auth-form .btn {
+  padding: 0.6rem;
+}


### PR DESCRIPTION
## Summary
- redesign login page and sign up page
- revamp password recovery pages
- update member and confirmation views
- modern layout styles for auth module

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_684bb01703d88331993f8bf55e573527