### PR TITLE
Add Angular dashboard module

### DIFF
--- a/frontend/src/app/point/dashboard/dashboard-routing.module.ts
+++ b/frontend/src/app/point/dashboard/dashboard-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { DashboardPageComponent } from './pages/dashboard-page/dashboard-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    children: [
+      { path: 'home', component: DashboardPageComponent },
+      { path: '**', redirectTo: 'home', pathMatch: 'full' },
+    ]
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class DashboardRoutingModule { }

--- a/frontend/src/app/point/dashboard/dashboard.module.ts
+++ b/frontend/src/app/point/dashboard/dashboard.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { DashboardRoutingModule } from './dashboard-routing.module';
+import { DashboardPageComponent } from './pages/dashboard-page/dashboard-page.component';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [DashboardPageComponent],
+  imports: [
+    CommonModule,
+    DashboardRoutingModule,
+    FormsModule,
+  ]
+})
+export class DashboardModule { }

--- a/frontend/src/app/point/dashboard/pages/dashboard-page/dashboard-page.component.css
+++ b/frontend/src/app/point/dashboard/pages/dashboard-page/dashboard-page.component.css
@@ -1,0 +1,9 @@
+.material-symbols-outlined {
+  font-size: 4rem;
+}
+
+@media (min-width: 768px) {
+  .margin {
+    margin-top: 20%;
+  }
+}

--- a/frontend/src/app/point/dashboard/pages/dashboard-page/dashboard-page.component.html
+++ b/frontend/src/app/point/dashboard/pages/dashboard-page/dashboard-page.component.html
@@ -1,0 +1,64 @@
+<div class="container-sm row m-auto p-1" style="max-height: 100%;">
+
+  <div class="row col-12 col-md-10 card bg-primary m-auto my-2">
+    <div class="row d-flex justify-content-center align-items-center">
+      <div class="col-10">
+        <h6>Bienvenido,</h6>
+        <h2>{{ identityUser?.nombre }}</h2>
+      </div>
+    </div>
+  </div>
+
+  <div class="row col-12 col-md-10 card bg-primary m-auto my-2 p-2 text-center">
+    <div class="col-6 col-md-3">
+      <h6>Ventas hoy</h6>
+      <p>{{ totalVentas | currency }}</p>
+    </div>
+    <div class="col-6 col-md-3">
+      <h6>Productos</h6>
+      <p>{{ totalProductos }}</p>
+    </div>
+    <div class="col-6 col-md-3">
+      <h6>Usuarios</h6>
+      <p>{{ totalUsuarios }}</p>
+    </div>
+  </div>
+
+  <div class="row col-12 col-md-10 card bg-primary m-auto my-2">
+    <div class="card-header">Últimas Ventas</div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item d-flex justify-content-between" *ngFor="let v of ventas">
+        <span>{{ v.fecha_venta }}</span>
+        <span>{{ v.total_venta | currency }}</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="p-0 mx-auto row d-flex col-12 col-md-10 margin">
+    <div class="card col-6 col-md-3 p-0 my-1" role="button" routerLink="/point/product/home">
+      <div class="bg-primary h-100 text-center p-0 m-0 d-flex flex-column justify-content-center">
+        <span class="material-symbols-outlined">shopping_cart</span>
+        <p style="font-size: .75rem;">Ventas</p>
+      </div>
+    </div>
+    <div class="card col-6 col-md-3 p-0 my-1" role="button" routerLink="/point/product/inventario">
+      <div class="bg-primary h-100 text-center p-0 m-0 d-flex flex-column justify-content-center">
+        <span class="material-symbols-outlined">store</span>
+        <p style="font-size: .75rem;">Inventario</p>
+      </div>
+    </div>
+    <div class="card col-6 col-md-3 p-0 my-1" role="button" routerLink="/point/user/equipo">
+      <div class="bg-primary h-100 text-center p-0 m-0 d-flex flex-column justify-content-center">
+        <span class="material-symbols-outlined">group</span>
+        <p style="font-size: .75rem;">Usuarios</p>
+      </div>
+    </div>
+    <div class="card col-6 col-md-3 p-0 my-1" role="button" routerLink="/point/user/ventas">
+      <div class="bg-primary h-100 text-center p-0 m-0 d-flex flex-column justify-content-center">
+        <span class="material-symbols-outlined">history</span>
+        <p style="font-size: .75rem;">Historial</p>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/frontend/src/app/point/dashboard/pages/dashboard-page/dashboard-page.component.ts
+++ b/frontend/src/app/point/dashboard/pages/dashboard-page/dashboard-page.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpHeaders } from '@angular/common/http';
+import { throwError } from 'rxjs';
+import { VentasService } from 'src/app/point/ventas/services/ventas.service';
+import { ProductoService } from 'src/app/point/products/services/producto.service';
+import { UserServices } from 'src/app/point/users/services/user.service';
+import { AuthService } from 'src/app/auth/services/auth.service';
+
+@Component({
+  selector: 'app-dashboard-page',
+  templateUrl: './dashboard-page.component.html',
+  styleUrls: ['./dashboard-page.component.css']
+})
+export class DashboardPageComponent implements OnInit {
+
+  identityUser = JSON.parse(localStorage.getItem('identity_user'));
+  totalVentas: number = 0;
+  totalProductos: number = 0;
+  totalUsuarios: number = 0;
+  ventas: any[] = [];
+  options: any = {};
+
+  constructor(
+    private ventasService: VentasService,
+    private productoService: ProductoService,
+    private userService: UserServices,
+    private authService: AuthService,
+  ) { }
+
+  ngOnInit() {
+    this.authService.checkSignIn(this.identityUser);
+    this.loadVentas();
+    this.loadProductos();
+    this.loadUsuarios();
+  }
+
+  getHeaders(token: string) {
+    let headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      'Authorization': token
+    });
+    return headers;
+  }
+
+  loadVentas() {
+    this.options.headers = this.identityUser ? this.getHeaders(this.identityUser.token) : throwError;
+    this.ventasService.getVentas(this.options).subscribe({
+      next: (data) => {
+        this.ventas = data.slice(0, 5);
+      }
+    });
+    this.ventasService.getTotalVentas({ headers: this.identityUser ? this.getHeaders(this.identityUser.token) : null }).subscribe({
+      next: (total) => {
+        this.totalVentas = total ? total : 0;
+      }
+    });
+  }
+
+  loadProductos() {
+    this.options.headers = this.identityUser ? this.getHeaders(this.identityUser.token) : throwError;
+    this.productoService.getProdutos(this.options).subscribe({
+      next: (data) => {
+        this.totalProductos = data.length;
+      }
+    });
+  }
+
+  loadUsuarios() {
+    this.options.headers = this.identityUser ? this.getHeaders(this.identityUser.token) : throwError;
+    this.userService.getUsers(this.options).subscribe({
+      next: (data) => {
+        this.totalUsuarios = data.length;
+      }
+    });
+  }
+
+}

--- a/frontend/src/app/point/layout/components/sidenav/sidenav.component.html
+++ b/frontend/src/app/point/layout/components/sidenav/sidenav.component.html
@@ -5,6 +5,10 @@
   </div>
 
   <div class="d-flex flex-md-column justify-content-evenly align-self-start" style="width: inherit;">
+    <div role="button" routerLinkActive="active" [routerLink]="['/point/dashboard/home']" class="py-2 list-group-item mx-md-0 d-flex justify-content-center align-items-center">
+      <span class="material-symbols-outlined">dashboard</span>
+      <span>Inicio</span>
+    </div>
     <div role="button" routerLinkActive="active" [routerLink]="['/point/product/home']" class="py-2 list-group-item mx-md-0 d-flex justify-content-center align-items-center">
       <span class="material-symbols-outlined">home</span>
       <span>Ventas</span>

--- a/frontend/src/app/point/point-routing.module.ts
+++ b/frontend/src/app/point/point-routing.module.ts
@@ -7,6 +7,12 @@ const routes: Routes = [
   {
     path: '',
     children: [{
+      path: 'dashboard', loadChildren: () => import('./dashboard/dashboard.module').then(m => m.DashboardModule), component: LayoutPointPageComponent,
+    }],
+  },
+  {
+    path: '',
+    children: [{
       path: 'product', loadChildren: () => import('./products/products.module').then(m => m.ProductsModule), component: LayoutPointPageComponent,
     }],
   },
@@ -19,7 +25,7 @@ const routes: Routes = [
   {
     path: '',
     children: [{
-      path: "**", redirectTo: 'point', pathMatch: 'full'
+      path: "**", redirectTo: 'dashboard/home', pathMatch: 'full'
     }]
   },
 ];


### PR DESCRIPTION
## Summary
- add DashboardModule with a dashboard page
- update routing to include `/point/dashboard`
- show the dashboard entry in the side navigation

## Testing
- `npm --prefix backend test` *(fails: Error: no test specified)*
- `npm --prefix frontend test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c755060348331beb2bc4dd4f77b55