### PR TITLE
Use bootstrap for auth views

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -23,6 +23,7 @@
             ],
             "styles": [
               "src/styles.css",
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "node_modules/ngx-toastr/toastr.css"
             ],
             "scripts": []
@@ -104,7 +105,8 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.css",
+              "node_modules/bootstrap/dist/css/bootstrap.min.css"
             ],
             "scripts": []
           }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "frontend": "file:",
     "jasmine": "^5.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
+    "bootstrap": "^5.3.2",
     "md5-typescript": "^1.0.5",
     "ngx-toastr": "^17.0.2",
     "rxjs": "~7.8.0",

--- a/frontend/src/app/auth/pages/forgot-pwd-page/forgot-pwd-page.component.html
+++ b/frontend/src/app/auth/pages/forgot-pwd-page/forgot-pwd-page.component.html
@@ -3,7 +3,9 @@
 </h3>
 <form [formGroup]="formForgotPwd" (ngSubmit)="forgotPwd()" class="auth-form">
   <div class="form-floating mb-2">
-    <input type="email" id="correo" placeholder="Correo" class="form-control" formControlName="correo">
+    <input type="email" id="correo" placeholder="Correo" class="form-control"
+      formControlName="correo"
+      [ngClass]="{'is-invalid': correo.invalid && (correo.dirty || correo.touched)}">
     <label for="correo">Correo</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">

--- a/frontend/src/app/auth/pages/login-page/login-page.component.html
+++ b/frontend/src/app/auth/pages/login-page/login-page.component.html
@@ -3,7 +3,9 @@
 </h3>
 <form [formGroup]="formSignIn" (ngSubmit)="signIn()" class="auth-form">
   <div class="form-floating mb-2">
-    <input type="email" id="correo" placeholder="Correo" class="form-control" formControlName="correo">
+    <input type="email" id="correo" placeholder="Correo" class="form-control"
+      formControlName="correo"
+      [ngClass]="{'is-invalid': correo.invalid && (correo.dirty || correo.touched)}">
     <label for="correo">Correo</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
@@ -13,7 +15,9 @@
     Correo electronico no valido
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control" formControlName="contrasenia">
+    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control"
+      formControlName="contrasenia"
+      [ngClass]="{'is-invalid': contrasenia.invalid && (contrasenia.dirty || contrasenia.touched)}">
     <label for="contrasenia">Contraseña</label>
   </div>
   <div class="text-danger small text-center mb-3" *ngIf="(contrasenia.dirty && contrasenia.touched && contrasenia.errors?.required)">

--- a/frontend/src/app/auth/pages/new-member/new-member.component.html
+++ b/frontend/src/app/auth/pages/new-member/new-member.component.html
@@ -3,14 +3,18 @@
 </h3>
 <form [formGroup]="formMember" (ngSubmit)="createUser()" class="auth-form">
   <div class="form-floating mb-2">
-    <input type="text" id="nombre" placeholder="Nombre" class="form-control" formControlName="nombre">
+    <input type="text" id="nombre" placeholder="Nombre" class="form-control"
+      formControlName="nombre"
+      [ngClass]="{'is-invalid': nombre.invalid && (nombre.dirty || nombre.touched)}">
     <label for="nombre">Nombre</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(nombre.touched && nombre.dirty && nombre.errors?.required)">
     Ingresa tu nombre
   </div>
   <div class="form-floating mb-2">
-    <input type="email" id="correo" placeholder="Correo electronico" class="form-control" formControlName="correo">
+    <input type="email" id="correo" placeholder="Correo electronico" class="form-control"
+      formControlName="correo"
+      [ngClass]="{'is-invalid': correo.invalid && (correo.dirty || correo.touched)}">
     <label for="correo">Correo electronico</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
@@ -20,7 +24,9 @@
     Correo no valido
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control" formControlName="contrasenia">
+    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control"
+      formControlName="contrasenia"
+      [ngClass]="{'is-invalid': contrasenia.invalid && (contrasenia.dirty || contrasenia.touched)}">
     <label for="contrasenia">Contraseña</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
@@ -30,7 +36,9 @@
     La contraseña debe tener de 8 a 12 caracteres
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control" formControlName="confContrasenia">
+    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control"
+      formControlName="confContrasenia"
+      [ngClass]="{'is-invalid': confContrasenia.invalid && (confContrasenia.dirty || confContrasenia.touched)}">
     <label for="confContrasenia">Confirmar contraseña</label>
   </div>
   <div class="text-danger small text-center mb-3" *ngIf="(formMember.errors?.PasswordNoMatch && confContrasenia.value)">

--- a/frontend/src/app/auth/pages/restore-pwd-page/restore-pwd-page.component.html
+++ b/frontend/src/app/auth/pages/restore-pwd-page/restore-pwd-page.component.html
@@ -3,7 +3,9 @@
 </h3>
 <form [formGroup]="formRestorePwd" (ngSubmit)="restorePwd()" class="auth-form">
   <div class="form-floating mb-2">
-    <input type="email" id="correo" placeholder="Correo" class="form-control" formControlName="correo">
+    <input type="email" id="correo" placeholder="Correo" class="form-control"
+      formControlName="correo"
+      [ngClass]="{'is-invalid': correo.invalid && (correo.dirty || correo.touched)}">
     <label for="correo">Correo</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
@@ -13,7 +15,9 @@
     Correo electronico no valido
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="contrasenia" placeholder="Nueva contraseña" class="form-control" formControlName="contrasenia">
+    <input type="password" id="contrasenia" placeholder="Nueva contraseña" class="form-control"
+      formControlName="contrasenia"
+      [ngClass]="{'is-invalid': contrasenia.invalid && (contrasenia.dirty || contrasenia.touched)}">
     <label for="contrasenia">Nueva contraseña</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
@@ -23,7 +27,9 @@
     La contraseña debe tener de 8 a 12 caracteres
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control" formControlName="confContrasenia">
+    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control"
+      formControlName="confContrasenia"
+      [ngClass]="{'is-invalid': confContrasenia.invalid && (confContrasenia.dirty || confContrasenia.touched)}">
     <label for="confContrasenia">Confirmar contraseña</label>
   </div>
   <div class="text-danger small text-center mb-3" *ngIf="(formRestorePwd.errors?.PasswordNoMatch && confContrasenia.value)">

--- a/frontend/src/app/auth/pages/signup-page/signup-page.component.html
+++ b/frontend/src/app/auth/pages/signup-page/signup-page.component.html
@@ -3,14 +3,18 @@
 </h3>
 <form [formGroup]="formSignUp" (ngSubmit)="createUser()" class="auth-form">
   <div class="form-floating mb-2">
-    <input type="text" id="nombre" placeholder="Nombre" class="form-control" formControlName="nombre">
+    <input type="text" id="nombre" placeholder="Nombre" class="form-control"
+      formControlName="nombre"
+      [ngClass]="{'is-invalid': nombre.invalid && (nombre.dirty || nombre.touched)}">
     <label for="nombre">Nombre</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(nombre.touched && nombre.dirty && nombre.errors?.required)">
     Ingresa tu nombre
   </div>
   <div class="form-floating mb-2">
-    <input type="email" id="correo" placeholder="Correo electronico" class="form-control" formControlName="correo">
+    <input type="email" id="correo" placeholder="Correo electronico" class="form-control"
+      formControlName="correo"
+      [ngClass]="{'is-invalid': correo.invalid && (correo.dirty || correo.touched)}">
     <label for="correo">Correo electronico</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(correo.touched && correo.dirty && correo.errors?.required)">
@@ -20,11 +24,15 @@
     Correo no valido
   </div>
   <div class="form-floating mb-2">
-    <input type="text" id="nombre_equipo" placeholder="Nombre de tu equipo" class="form-control" formControlName="nombre_equipo">
+    <input type="text" id="nombre_equipo" placeholder="Nombre de tu equipo" class="form-control"
+      formControlName="nombre_equipo"
+      [ngClass]="{'is-invalid': nombre_equipo.invalid && (nombre_equipo.dirty || nombre_equipo.touched)}">
     <label for="nombre_equipo">Nombre de tu equipo</label>
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control" formControlName="contrasenia">
+    <input type="password" id="contrasenia" placeholder="Contraseña" class="form-control"
+      formControlName="contrasenia"
+      [ngClass]="{'is-invalid': contrasenia.invalid && (contrasenia.dirty || contrasenia.touched)}">
     <label for="contrasenia">Contraseña</label>
   </div>
   <div class="text-danger small text-center mb-2" *ngIf="(contrasenia.touched && contrasenia.dirty && contrasenia.errors?.required)">
@@ -34,7 +42,9 @@
     La contraseña debe tener de 8 a 12 caracteres
   </div>
   <div class="form-floating mb-2">
-    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control" formControlName="confContrasenia">
+    <input type="password" id="confContrasenia" placeholder="Confirmar contraseña" class="form-control"
+      formControlName="confContrasenia"
+      [ngClass]="{'is-invalid': confContrasenia.invalid && (confContrasenia.dirty || confContrasenia.touched)}">
     <label for="confContrasenia">Confirmar contraseña</label>
   </div>
   <div class="text-danger small text-center mb-3" *ngIf="(formSignUp.errors?.PasswordNoMatch && confContrasenia.value)">

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,12 +8,6 @@
   <meta name=description content="Point es un punto de venta útil, eficaz y sencillo.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <!-- JS Bootstrap -->
-  <script async src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
-    crossorigin="anonymous"></script>
-  <!-- Bootstrap -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" media="print" onload="this.media='all'">
   <!-- Material icon -->
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
    <!-- Polyfill de Zone.js desde el CDN -->


### PR DESCRIPTION
## Summary
- integrate Bootstrap via package.json
- load Bootstrap styles globally
- remove CDN references from index.html
- enhance auth forms with Bootstrap validation classes

## Testing
- `npm test` *(fails: ng not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c9412cc98833189bb6eb6915cadd8