### PR TITLE
Improve UI/UX for product home

### DIFF
--- a/frontend/src/app/point/products/components/modal-addproducts/modal-addproducts.component.html
+++ b/frontend/src/app/point/products/components/modal-addproducts/modal-addproducts.component.html
@@ -10,19 +10,19 @@
           <div class="d-flex row justify-content-center">
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="text" id="floatingDescripcion" placeholder="Descripcion" formControlName="descripcion">
-              <label for="floatingDescripcion">Descripcion</label>
+              <label for="floatingDescripcion">Descripcion <span class="text-danger">*</span></label>
             </div>
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="number" id="floatingPrecio" placeholder="Precio" formControlName="precio">
-              <label for="floatingPrecio">Precio</label>
+              <label for="floatingPrecio">Precio <span class="text-danger">*</span></label>
             </div>
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="number" id="floatingCantidad" placeholder="Cantidad" formControlName="cantidad">
-              <label for="floatingCantidad">Cantidad</label>
+              <label for="floatingCantidad">Cantidad <span class="text-danger">*</span></label>
             </div>
             <div class="form-floating input-group p-0 m-0 my-1">
               <input class="form-control" type="text" id="floatingCodigo" placeholder="Codigo" formControlName="codigo">
-              <button class="btn btn-primary btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#scanBarcode" (click)="camaraEstatus()">
+              <button class="btn btn-primary btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#scanBarcode" (click)="camaraEstatus()" aria-label="Escanear" title="Escanear código">
                 <span style="color: white;" class="material-symbols-outlined">barcode_scanner</span>
               </button>
               <label for="floatingCodigo">Codigo</label>

--- a/frontend/src/app/point/products/components/modal-editproducto-venta/modal-editproducto-venta.component.html
+++ b/frontend/src/app/point/products/components/modal-editproducto-venta/modal-editproducto-venta.component.html
@@ -6,17 +6,17 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body d-flex justify-content-evenly">
-        <button type="button" class="btn btn-danger d-flex align-items-center" [attr.disabled]="isDisabledAdd" (click)="edit(1)">
+        <button type="button" class="btn btn-danger d-flex align-items-center" [attr.disabled]="isDisabledAdd" (click)="edit(1)" aria-label="Aumentar">
           <span class="material-symbols-outlined">
             add
           </span>
         </button>
-        <button type="button" class="btn btn-danger d-flex align-items-center" data-bs-dismiss="modal" (click)="edit(0)">
+        <button type="button" class="btn btn-danger d-flex align-items-center" data-bs-dismiss="modal" (click)="edit(0)" aria-label="Eliminar del carro">
           <span class="material-symbols-outlined">
             delete
           </span>
         </button>
-        <button type="button" class="btn btn-danger d-flex align-items-center" [attr.data-bs-dismiss]="modal" (click)="edit(-1)">
+        <button type="button" class="btn btn-danger d-flex align-items-center" [attr.data-bs-dismiss]="modal" (click)="edit(-1)" aria-label="Disminuir">
           <span class="material-symbols-outlined">
             remove
           </span>

--- a/frontend/src/app/point/products/components/modal-editproducts/modal-editproducts.component.html
+++ b/frontend/src/app/point/products/components/modal-editproducts/modal-editproducts.component.html
@@ -11,15 +11,15 @@
           <div class="d-flex row justify-content-center">
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="text" id="floatingDescripcion" formControlName="descripcion">
-              <label for="floatingDescripcion">Descripcion</label>
+              <label for="floatingDescripcion">Descripcion <span class="text-danger">*</span></label>
             </div>
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="number" id="floatingPrecio" formControlName="precio">
-              <label for="floatingPrecio">Precio</label>
+              <label for="floatingPrecio">Precio <span class="text-danger">*</span></label>
             </div>
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="number" id="floatingCantidad" formControlName="cantidad">
-              <label for="floatingCantidad">Cantidad</label>
+              <label for="floatingCantidad">Cantidad <span class="text-danger">*</span></label>
             </div>
             <div class="form-floating p-0 m-0 my-1">
               <input class="form-control" type="number" id="floatingCodigo" formControlName="codigo">

--- a/frontend/src/app/point/products/components/modal-scan-barcode/modal-scan-barcode.component.html
+++ b/frontend/src/app/point/products/components/modal-scan-barcode/modal-scan-barcode.component.html
@@ -3,16 +3,17 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title fs-5" id="exampleModalLabel">Escanear codigo de barras</h5>
-        <button id="cerrarScan" type="button" class="btn-close" data-bs-target="#addProducto" data-bs-toggle="modal" aria-label="Close" (click)="camaraEstatus()"></button>
+        <button id="cerrarScan" type="button" class="btn-close" data-bs-target="#addProducto" data-bs-toggle="modal" aria-label="Cerrar" (click)="camaraEstatus()"></button>
       </div>
       <div class="modal-body">
+        <p class="text-center" *ngIf="camara">Apunte la cámara al código de barras</p>
         <zxing-scanner
         *ngIf="camara"
         autofocus="true"
         (scanSuccess)="scanSuccessHandler($event)"
         [formats]="['QR_CODE', 'EAN_13', 'CODE_128', 'DATA_MATRIX']"
-        >
-      </zxing-scanner>
-    </div>
+        ></zxing-scanner>
+        <p class="text-center" *ngIf="!camara">No se detectó ningún código</p>
+      </div>
   </div>
 </div>

--- a/frontend/src/app/point/products/components/ventas/ventas.component.html
+++ b/frontend/src/app/point/products/components/ventas/ventas.component.html
@@ -1,7 +1,7 @@
   <app-modal-editproducto-venta class="d-md-none" [producto]="producto"
     (editEvent)="eliminar(producto)"></app-modal-editproducto-venta>
-  <div class="container-fluid tab pt-3 h-50 px-0 text-center">
-    <table class="table table-hover table-striped align-middle" style="border-radius: 1em; overflow: hidden;">
+  <div class="container-fluid tab pt-3 h-50 px-0 text-center table-responsive">
+    <table class="table table-hover table-striped align-middle" style="border-radius: 1em;">
       <thead>
         <tr class="table-info">
           <th>Producto</th>
@@ -10,7 +10,7 @@
           <th>Total</th>
           <th class="d-xs-none">
             <ng-container *ngIf="ventaProductos.length > 0">
-              <button class="btn btn-danger btn-sm mx-1" (click)="borrarCuenta()">Borrar cuenta</button>
+              <button class="btn btn-danger btn-sm mx-1" (click)="borrarCuenta()" title="Vaciar venta" aria-label="Vaciar venta">Borrar cuenta</button>
             </ng-container>
           </th>
         </tr>
@@ -21,20 +21,32 @@
           <td class="overflow-x-hidden text-nowrap" style="max-width: 1em;">{{ producto.descripcion | titlecase }}</td>
           <td>{{ producto.precio | currency }}</td>
           <td>
-            <input
-              type="number"
-              min="1"
-              [max]="producto.stock"
-              [value]="producto.cantidad"
-              class="input-cantidad"
-              [(ngModel)]="producto.cantidad"
-              [ngClass]="{ 'max-stock': producto.cantidad >= producto.stock }"
-              (change)="actualizarCantidad(i)"
-            >
+            <div class="input-group input-group-sm justify-content-center cantidad-control" (click)="$event.stopPropagation()">
+              <button type="button" class="btn btn-outline-secondary" aria-label="Restar"
+                (click)="cambiarCantidad(i, -1); $event.stopPropagation()" [disabled]="producto.cantidad <= 1">
+                <span class="material-symbols-outlined" aria-hidden="true">remove</span>
+              </button>
+              <input
+                type="number"
+                min="1"
+                [max]="producto.stock"
+                [value]="producto.cantidad"
+                class="input-cantidad form-control text-center"
+                [(ngModel)]="producto.cantidad"
+                [ngClass]="{ 'max-stock': producto.cantidad >= producto.stock }"
+                (change)="actualizarCantidad(i)"
+                aria-label="Cantidad"
+              >
+              <button type="button" class="btn btn-outline-secondary" aria-label="Sumar"
+                (click)="cambiarCantidad(i, 1); $event.stopPropagation()" [disabled]="producto.cantidad >= producto.stock">
+                <span class="material-symbols-outlined" aria-hidden="true">add</span>
+              </button>
+            </div>
+            <small *ngIf="producto.cantidad >= producto.stock" class="text-danger">Stock máximo alcanzado</small>
           </td>
           <td>{{ producto.cantidad * producto.precio | currency }}</td>
           <td class="d-xs-none">
-            <button type="button" class="btn btn-danger btn-sm mx-1" (click)="eliminar(producto)">
+            <button type="button" class="btn btn-danger btn-sm mx-1" (click)="eliminar(producto)" title="Eliminar producto" aria-label="Eliminar producto">
               <span class="material-symbols-outlined">
                 delete
               </span>
@@ -60,16 +72,16 @@
       <div class="input-group">
         <input name="productoInput" type="text" autocomplete="off" class="form-control input-group text-capitalize" placeholder="Buscar producto..."
           aria-label="Producto" [(ngModel)]="productoBuscado" (keyup)="getProductos()">
-        <button class="btn btn-primary btn-outline-secondary" type="button" data-bs-toggle="modal"
-          data-bs-target="#scanBarcode" (click)="camaraEstatus()">
+        <button class="btn btn-primary btn-outline-secondary me-2" type="button" data-bs-toggle="modal"
+          data-bs-target="#scanBarcode" (click)="camaraEstatus()" title="Escanear código de barras" aria-label="Escanear código">
           <span style="color: white;" class="material-symbols-outlined">barcode_scanner</span>
         </button>
-        <button class="btn btn-primary" [attr.disabled]="isDisabledVender" (click)="venta()" type="button">Vender</button>
+        <button class="btn btn-primary" [disabled]="isDisabledVender" (click)="venta()" type="button" title="Completar venta" aria-label="Vender">Vender</button>
       </div>
     </form>
   </div>
 
-  <div class="tab container-fluid" style="height: 15%;">
+  <div class="tab container-fluid table-responsive" style="height: 15%;">
     <table class="table table-hover tab" style="border-radius: 1em;">
       <tbody>
         <tr *ngFor="let item of listProductos" class="table-dark" role="button" (click)="selectProducto(item)">

--- a/frontend/src/app/point/products/components/ventas/ventas.component.ts
+++ b/frontend/src/app/point/products/components/ventas/ventas.component.ts
@@ -70,6 +70,16 @@ export class VentasComponent {
       }
     }
 
+    cambiarCantidad(index: number, delta: number) {
+      if (!this.ventaProductos[index]) return;
+      this.ventaProductos[index].cantidad += delta;
+      if (this.ventaProductos[index].cantidad <= 0) {
+        this.eliminar(this.ventaProductos[index]);
+        return;
+      }
+      this.actualizarCantidad(index);
+    }
+
     edit(item: any) {
       if (item.cantidad <= 1) {
         document.getElementById(String(`${item.id}remove`)).setAttribute('disabled', 'true')

--- a/frontend/src/app/point/products/pages/home-page/home-page.component.css
+++ b/frontend/src/app/point/products/pages/home-page/home-page.component.css
@@ -1,5 +1,6 @@
+
 .tab {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .tab::-webkit-scrollbar {

--- a/frontend/src/app/point/products/pages/home-page/home-page.component.html
+++ b/frontend/src/app/point/products/pages/home-page/home-page.component.html
@@ -9,9 +9,10 @@
     >
       <button
         type="button"
-        class="btn-close position-absolute top-0 end-0 z-index-10"
-        aria-label="Close"
+        class="btn-close btn-sm position-absolute top-0 end-0 z-index-10 m-1"
+        aria-label="Cerrar cuenta"
         (click)="borrarCliente(i); $event.stopPropagation()"
+        title="Eliminar cuenta"
       ></button>
       <span>Cliente {{ cliente.id }}</span>
       <span>{{ cliente.totalVenta | currency }}</span>
@@ -23,6 +24,8 @@
     class="text-center my-1 d-flex justify-content-center flex-column border border-dark card"
     style="height: 6rem;"
     (click)="nuevaCuenta()"
+    aria-label="Agregar cuenta"
+    title="Agregar cuenta"
   >
     <span>Agregar cuenta</span>
     <span class="material-symbols-outlined" style="font-size: 2rem;">

--- a/frontend/src/app/point/products/pages/home-page/home-page.component.ts
+++ b/frontend/src/app/point/products/pages/home-page/home-page.component.ts
@@ -29,6 +29,8 @@ export class HomePageComponent {
     this.clienteVisible = this.clientes[i].id;
   }
   borrarCliente(i: number) {
+    const confirmDelete = confirm('¿Eliminar cuenta de cliente?');
+    if (!confirmDelete) return;
     this.clientes.splice(i, 1);
     if (this.clientes.length < 1) {
       this.clientes = [


### PR DESCRIPTION
## Summary
- add confirmation prompt before removing clients
- tweak client cards and add aria-labels
- use buttons to change product quantity and show stock limit message
- adjust selling controls with tooltips and disabled state
- mark required fields in product modals
- add basic instructions to barcode scanner modal
- improve accessibility labels
- minor CSS update for scroll behavior

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb6567de48331b5cb9153bde480ff