### PR TITLE
Fix responsive issues and cleanup

### DIFF
--- a/frontend/src/app/auth/pages/layout-auth-page/layout-auth-page.component.css
+++ b/frontend/src/app/auth/pages/layout-auth-page/layout-auth-page.component.css
@@ -14,8 +14,3 @@
   color: #fff;
 }
 
-@media (max-width: 576px) {
-  .d-xs-none {
-    display: none;
-  }
-}

--- a/frontend/src/app/point/notificaciones/pages/notificaciones-page/notificaciones-page.component.html
+++ b/frontend/src/app/point/notificaciones/pages/notificaciones-page/notificaciones-page.component.html
@@ -11,7 +11,7 @@
             {{ notificacion.fecha }}
           </td>
           <td>
-            <button type="submit" class="btn btn-danger btn-sm mx-sm-1 resposive-button w-100"
+            <button type="submit" class="btn btn-danger btn-sm mx-sm-1 responsive-button w-100"
               (click)="delete(notificacion.id)">
               <span class="material-symbols-outlined">
                 delete

--- a/frontend/src/app/point/products/components/ventas/ventas.component.html
+++ b/frontend/src/app/point/products/components/ventas/ventas.component.html
@@ -8,7 +8,7 @@
           <th>Precio</th>
           <th>Cantidad</th>
           <th>Total</th>
-          <th class="d-xs-none">
+          <th class="d-none d-sm-table-cell">
             <ng-container *ngIf="ventaProductos.length > 0">
               <button class="btn btn-danger btn-sm mx-1" (click)="borrarCuenta()">Borrar cuenta</button>
             </ng-container>
@@ -33,7 +33,7 @@
             >
           </td>
           <td>{{ producto.cantidad * producto.precio | currency }}</td>
-          <td class="d-xs-none">
+          <td class="d-none d-sm-table-cell">
             <button type="button" class="btn btn-danger btn-sm mx-1" (click)="eliminar(producto)">
               <span class="material-symbols-outlined">
                 delete

--- a/frontend/src/app/point/products/pages/home-page/home-page.component.css
+++ b/frontend/src/app/point/products/pages/home-page/home-page.component.css
@@ -11,11 +11,6 @@
   border-radius: .5rem;
 }
 
-@media (max-width: 576px) {
-  .d-xs-none {
-    display: none;
-  }
-}
 
 .input-cantidad {
   width: 3rem;

--- a/frontend/src/app/point/products/pages/inventario-page/inventario-page.component.css
+++ b/frontend/src/app/point/products/pages/inventario-page/inventario-page.component.css
@@ -11,12 +11,12 @@
   border-radius: .5rem;
 }
 
-.resposive-button{
+.responsive-button{
   width: 40%;
 }
 
 @media (max-width: 767.98px) {
-  .resposive-button{
+  .responsive-button{
     width: auto;
   }
 }

--- a/frontend/src/app/point/products/pages/inventario-page/inventario-page.component.html
+++ b/frontend/src/app/point/products/pages/inventario-page/inventario-page.component.html
@@ -5,7 +5,7 @@
       <thead>
         <tr class="table-info">
           <th>Producto</th>
-          <th style="max-width: auto;">Precio</th>
+          <th>Precio</th>
           <th>Cantidad</th>
           <th style="width: 10em;"></th>
         </tr>
@@ -24,13 +24,13 @@
           </td>
           <td>
             <div class="d-flex row p-0 m-0">
-              <button type="button" class="btn btn-primary btn-sm mx-sm-1 resposive-button" data-bs-toggle="modal"
+              <button type="button" class="btn btn-primary btn-sm mx-sm-1 responsive-button" data-bs-toggle="modal"
                 data-bs-target="#editProducto" (click)="setEditProducto(producto)">
                 <span class="material-symbols-outlined">
                   edit
                 </span>
               </button>
-              <button type="submit" class="btn btn-danger btn-sm mx-sm-1 resposive-button"
+              <button type="submit" class="btn btn-danger btn-sm mx-sm-1 responsive-button"
                 (click)="eliminar(producto.id)">
                 <span class="material-symbols-outlined">
                   delete

--- a/frontend/src/app/point/users/pages/home-users-page/home-users-page.component.css
+++ b/frontend/src/app/point/users/pages/home-users-page/home-users-page.component.css
@@ -2,7 +2,7 @@
   font-size: 4rem;
 }
 
-@media (min-width: 768) {
+@media (min-width: 768px) {
   .margin {
     margin-top: 20%;
   }

--- a/frontend/src/app/point/users/pages/home-users-page/home-users-page.component.html
+++ b/frontend/src/app/point/users/pages/home-users-page/home-users-page.component.html
@@ -16,7 +16,7 @@
         <div class="col-2 p-0 m-0">
           <img class="rounded-circle"
             src="https://img.freepik.com/vector-premium/imagen-perfil-avatar-hombre-ilustracion-vectorial_268834-538.jpg?size=338&ext=jpg&ga=GA1.1.1880011253.1705190400&semt=ais"
-            style="width: 3rem; height: 3rem;">
+            style="width: 3rem; height: 3rem;" alt="Usuario">
         </div>
       </div>
     </div>

--- a/frontend/src/app/point/ventas/pages/ventas-page/ventas-page.component.css
+++ b/frontend/src/app/point/ventas/pages/ventas-page/ventas-page.component.css
@@ -1,5 +1,5 @@
 @media (max-width: 767.98px) {
-  .resposive-button{
+  .responsive-button{
     width: auto;
   }
 }

--- a/frontend/src/app/point/ventas/pages/ventas-page/ventas-page.component.html
+++ b/frontend/src/app/point/ventas/pages/ventas-page/ventas-page.component.html
@@ -19,20 +19,20 @@
             {{ venta.fecha_venta }}
           </td>
           <td>
-            <div class="d-flex row p-0 m-0 resposive-button">
-              <button type="button" class="btn btn-primary btn-sm mx-sm-1 resposive-button" data-bs-toggle="modal"
+            <div class="d-flex row p-0 m-0 responsive-button">
+              <button type="button" class="btn btn-primary btn-sm mx-sm-1 responsive-button" data-bs-toggle="modal"
                 data-bs-target="#editVenta" (click)="getVenta(venta.id)">
                 <span class="material-symbols-outlined">
                   edit
                 </span>
               </button>
-              <button type="submit" class="btn btn-danger btn-sm mx-sm-1 resposive-button"
+              <button type="submit" class="btn btn-danger btn-sm mx-sm-1 responsive-button"
                 (click)="deleteVenta(venta.id)">
                 <span class="material-symbols-outlined">
                   delete
                 </span>
               </button>
-              <button class="btn btn-sm mx-sm-1 resposive-button w-auto" *ngIf="venta?.id_modificado"
+              <button class="btn btn-sm mx-sm-1 responsive-button w-auto" *ngIf="venta?.id_modificado"
                 data-bs-toggle="collapse" [attr.data-bs-target]="'#id' + i" aria-expanded="false"
                 [attr.aria-controls]="'#id' + i" (click)="historialVentas(venta.id)">
                 <span class="material-symbols-outlined">


### PR DESCRIPTION
## Summary
- add missing `px` unit in Home Users page CSS
- remove custom `.d-xs-none` class
- rename typoed `resposive-button` to `responsive-button`
- clean up invalid max-width style
- add `alt` text to home user avatar

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684cc9f1d58c83318b394c718cf1fb50